### PR TITLE
Changed argument parsing for index and document commands.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -14,6 +14,12 @@
   revision = "3f9db97f856818214da2e1057f8ad84803971cff"
 
 [[projects]]
+  name = "github.com/jessevdk/go-flags"
+  packages = ["."]
+  revision = "96dc06278ce32a0e9d957d590bb987c81ee66407"
+  version = "v1.3.0"
+
+[[projects]]
   name = "github.com/mattn/go-colorable"
   packages = ["."]
   revision = "167de6bfdfba052fa6b2d3664c8f5272e23c9072"
@@ -52,6 +58,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "46245e1dd642b1802bc725c5082fdeab67b3b989ccfaccab7a060b679e46fa38"
+  inputs-digest = "3d46becc6636dcc1e05338062bb34805222a427700cae8f39d2d0a599a543bd0"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -29,3 +29,7 @@
   go-tests = true
   unused-packages = true
 
+
+[[constraint]]
+  name = "github.com/jessevdk/go-flags"
+  version = "1.3.0"

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"reflect"
 	"shelastic/es"
 
 	"github.com/fatih/color"
@@ -25,10 +26,11 @@ var (
 		Document(),
 	}
 
-	cl   = color.New(color.FgBlue).SprintfFunc()
+	bl   = color.New(color.FgBlue).SprintfFunc()
 	red  = color.New(color.FgRed).SprintFunc()
 	undr = color.New(color.Underline).SprintfFunc()
-	gr   = color.New(color.FgCyan).SprintfFunc()
+	cy   = color.New(color.FgCyan).SprintfFunc()
+	cyb  = color.New(color.FgHiCyan).SprintfFunc()
 )
 
 const (
@@ -146,11 +148,24 @@ func Debug() *ishell.Cmd {
 }
 
 func cprintln(c *ishell.Context, format string, params ...interface{}) {
-	c.Println(cl(format, params...))
+	c.Println(bl(format, params...))
 }
 
 func cprintf(c *ishell.Context, format string, params ...interface{}) {
-	c.Printf(cl(format, params...))
+	c.Printf(bl(format, params...))
+}
+
+// cprintlist prints list of parameters on a line. If parameter is a function it is printed as is, otherwise it is wrapped in default color
+// After all items are printed, new line is printed
+func cprintlist(c *ishell.Context, params ...interface{}) {
+	for _, item := range params {
+		if reflect.TypeOf(item).Kind() == reflect.Func {
+			c.Print(item)
+		} else {
+			c.Print(bl("%v", item))
+		}
+	}
+	c.Println()
 }
 
 func errorMsg(c *ishell.Context, message string, params ...interface{}) {

--- a/cmd/cmd_common.go
+++ b/cmd/cmd_common.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	flags "github.com/jessevdk/go-flags"
+)
+
+var (
+	errIndexNotSelected = "No index selected. Select index using 'use <index-name>' command or by passing --index <index-name> parameter"
+)
+
+type documentSelectorData struct {
+	Index    string `long:"index" description:"Index name"`
+	Document string `long:"doc" description:"Document type"`
+	Args     []string
+}
+
+type documentSelector interface {
+	GetIndex() string
+	GetDocument() string
+	GetArgs() []string
+
+	SetIndex(p string)
+	SetDocument(p string)
+	SetArgs(p []string)
+}
+
+func (ds *documentSelectorData) GetIndex() string {
+	return ds.Index
+}
+
+func (ds *documentSelectorData) GetDocument() string {
+	return ds.Document
+}
+
+func (ds *documentSelectorData) GetArgs() []string {
+	return ds.Args
+}
+
+func (ds *documentSelectorData) SetIndex(index string) {
+	ds.Index = index
+}
+
+func (ds *documentSelectorData) SetDocument(doc string) {
+	ds.Document = doc
+}
+
+func (ds *documentSelectorData) SetArgs(args []string) {
+	ds.Args = args
+}
+
+func parseDocumentArgs(args []string) (*documentSelectorData, error) {
+	res, err := parseDocumentArgsCustom(args, &documentSelectorData{})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*documentSelectorData), nil
+}
+
+func parseDocumentArgsCustom(args []string, customOpts interface{}) (interface{}, error) {
+	positional, err := flags.ParseArgs(customOpts, args)
+	if err != nil {
+		return nil, err
+	}
+
+	opts := customOpts.(documentSelector)
+	if opts.GetIndex() == "" {
+		opts.SetIndex(context.ActiveIndex)
+	}
+	opts.SetArgs(positional)
+
+	return customOpts, nil
+}

--- a/es/index.go
+++ b/es/index.go
@@ -249,6 +249,7 @@ func (e Es) ForceMerge(indexName string) error {
 	return err
 }
 
+// IndexShards is just a slice of IndexShard
 type IndexShards []IndexShard
 
 //IndexShards returns list of shards allocated for a given index
@@ -321,7 +322,7 @@ func (is IndexShards) Swap(i, j int) {
 	is[i], is[j] = is[j], is[i]
 }
 
-// IndexConfigure updates configuration for a given index. Configuration must be provided in YAML format
+// IndexConfigure updates configuration for a given index.
 func (e Es) IndexConfigure(indexName string, params map[string]string) error {
 	if len(params) == 0 {
 		return fmt.Errorf("No settings to update")
@@ -365,13 +366,14 @@ func (e Es) ResolveAndValidateIndex(indexName string) (string, error) {
 		}
 		for als := range e.aliases {
 			if indexName == e.aliases[als] {
-				return als, nil
+				return indexName, nil
 			}
 		}
 	}
 	return "", fmt.Errorf("Unknown index: %s", indexName)
 }
 
+// MoveAllShardsToNode changes index routing allocation to require given node
 func (e Es) MoveAllShardsToNode(index string, selector string, node string) error {
 	if node != "" {
 		node = "\"" + node + "\""

--- a/readme.md
+++ b/readme.md
@@ -16,21 +16,29 @@ This project is not affiliated with Elastic in any way.
 | `disconnect`                      | Disconnects from ES cluster. You need to disconnect before connecting to another cluster       |
 | `list indices`                    | Lists indices on the cluster |
 | `list nodes`                      | Lists nodes of the cluster. Each node is displayed in format `<name> @ <hostname> [<ip-address>]` |
+| `use <index-name>`                | Select index to be used for document manipulations. If no `<index-name>` is specified it will display index that is currently in use. To stop using index pass `--` argument to `use`, as in `use --` |
 | `_debug`                          | Toggle HTTP output. Use for bug reporting purposes |
 
 ### Index commads
 
+All index commands can accept index name as argument to `--index` option. By using 'use index-name' command one can "open" an index and it will be implicitly used in all document commands.
+
+Even when an index is in use, explicit index name may be supplied to any document command. Index specified with `--index` option will take precedence.
+
+Some of the commands (like `refresh` or `flush`) will be applied to all indices if no index name is specified. If an index is selected with `use` command it 
+first have to be deselected with `use --` for such commands to be applied to all indices in the cluster.
+
 | Command                            | Description                                                                                    |
 |:-----------------------------------|:-----------------------------------------------------------------------------------------------|
-| `index clear-cache [<index-name>]` | Clears cache of given index. If no `<index-name>` is specified then cache for all indices is cleared|
-| `index flush [<index-name>]`        | Flushes index. If no `<index-name>` given, flushesh all indices. Supported options: `force` - forces flush even if it is not needed; `wait` - waits for other ongoing flush operation to complete |
-| `index refresh [<index-name>]` | Refreshes index, making all operations performed since last refresh available for search.|
-| `index force-merge [<index-name>]` | Forces merging of one or more indices through an API. For ES version 1.x and 2.x this calls _Optimize_ API |
-| `index view mappings <index-name> [doc-name] [property-name]` | View mappings for index `<index-name>`. Optionally can display mappings only for specified document and/or property. Mappings are printed in YAML format for better readability|
-| `index view settings <index-name>` | View index settings|
-| `index view shards <index-name> [by-node | by-shard]` | View index shards|
-| `index configure <index-name> <config-item>`        | Set index setting. See below for syntax |
-| `index restrict <index-name> selector [<target>]`    | moves all shards to given node by selector. Selector can be one of `name`, `host` or `ip`. If `<target>` is not specified, then restriction is removed |
+| `index clear-cache [--index <index-name>]` | Clears cache of given index. If no index is in use then cache for all indices is cleared|
+| `index flush  [--index <index-name>] [--force] [--wait]`   | Flushes index. If no index is in use then flushes all indices. Supported options: `--force` - forces flush even if it is not needed; `--wait` - waits for other ongoing flush operation to complete |
+| `index refresh [--index <index-name>]` | Refreshes index, making all operations performed since last refresh available for search. If no index is in use then all indices are refreshed|
+| `index force-merge [--index <index-name>]` | Forces merging of one or more indices through an API. For ES version 1.x and 2.x this calls _Optimize_ API. If no index is in use then all indices are forced to merge |
+| `index view mappings [--index <index-name>] [--doc <doc-name>] [property-name]` | View mappings for index `<index-name>`. Optionally can display mappings only for specified document and/or property. Mappings are printed in YAML format for better readability|
+| `index view settings [--index <index-name>]` | View index settings|
+| `index view shards [--index <index-name>] [--mode by-node | by-shard]` | View index shards. If `--mode` option is not specified, `by-shard` is used|
+| `index configure [--index <index-name>] <config-item>`        | Set index setting. See below for syntax |
+| `index restrict [--index <index-name> selector [<target>]`    | moves all shards to given node by selector. Selector can be one of `name`, `host` or `ip`. If `<target>` is not specified, then restriction is removed |
 
 
 ### Snapshot commands
@@ -52,27 +60,23 @@ This project is not affiliated with Elastic in any way.
 | `node stats [node-name]`          | Displays node statistics. If `node-name` is specified then only this node stats are displayed otherwise statistics for all nodes is retrieved |
 | `node environment [node-name]`    | Displays node environment: OS name version and JVM name and version|
 | `node shards [<node-name>]`       | Displays indices and shards located on node. If node name is not specified, information is printed for all nodes|
-| `node decomission [<node-name>]`    | Disables allocation for given node. If node name is not specified then any cluster-wide allocation restrictions are removed|
+| `node decomission [<node-name>]`  | Disables allocation for given node. If node name is not specified then any cluster-wide allocation restrictions are removed|
 
 ### Document commands
 
-All document commands accept index name as first parameter. By using 'use index-name' command one can "open" an index and it will be implicitly used
-in all document commands.
+All document commands can accept index name as argument to `--index` option. By using 'use index-name' command one can "open" an index and it will be implicitly used in all document commands.
 
-Even when an index is in use, explicit index name may be supplied to any document command. Explicitly specified index will take precedence.
+Even when an index is in use, explicit index name may be supplied to any document command. Index specified with `--index` option will take precedence.
 
 | Command                           | Description                                                                                    |
 |:----------------------------------|:-----------------------------------------------------------------------------------------------|
-| `use <index-name>`                | Select index to be used for document manipulations. If no `<index-name>` is specified it will display index that is currently in use |
-| `document list [index]`                   | Lists all documents in index |
-| `document properties [index] <doc-name>`  | Lists properties of `<doc-name>` document. This does not display full metadata, just properies names
-and types |
-| `document get [index] <doc-name> <id>`    | Retrieves document by id |
-| `document delete [index] <doc-name> <id>` | Deletes document by id| 
-| `document search [index] [<doc-names>] <query>` | Search for query in `<doc-names>`. Document name can be omitted.|
-| `document query [index]`  | Search using Query DSL. Query must be entered as JSON at the prompt. This will always update "size" parameter to 20|
-| `document put [index] <doc-name> id`      | Upserts document into `index.doc-name` with id == id. This command will start multi-line editor to enter JSON
-of the document. Complete document with ";". Number of documents returned with this query will be limited to 20. If you need more results use `export` command |
+| `document list [--index <index-name>]`                   | Lists all documents in index |
+| `document properties [--index <index-name>] --doc <doc-name>`  | Lists properties of `<doc-name>` document. This does not display full metadata, just properies names and types |
+| `document get [--index <index-name>]--doc  <doc-name> <id>`    | Retrieves document by id |
+| `document delete [--index <index-name>] --doc <doc-name> <id>` | Deletes document by id| 
+| `document search [--index <index-name>] [--doc <doc-names>] <query>` | Search for query in `<doc-names>`. Document name can be omitted.|
+| `document query [--index <index-name>]`  | Search using Query DSL. Query must be entered as JSON at the prompt. This will always update "size" parameter to 20|
+| `document put [--index <index-name>] --doc <doc-name> id`      | Upserts document into `index.doc-name` with id == id. This command will start multi-line editor to enter JSON of the document. Complete document with ";". Number of documents returned with this query will be limited to 20. If you need more results use `export` command |
 
 ## Details
 


### PR DESCRIPTION
Using indexes is now more consistent across different commands which may accept index name.

Optional parameters are passed using `--arg` arguments across all commands.