### PR TITLE
Added index copy command

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -191,6 +191,19 @@ func cprintlist(c *ishell.Context, params ...interface{}) {
 	c.Println()
 }
 
+// cprintl prints list of parameters on a line. If parameter is a function it is printed as is, otherwise it is wrapped in default color
+// No new line after all is printed
+func cprintl(c *ishell.Context, params ...interface{}) {
+	for _, item := range params {
+		if reflect.TypeOf(item).Kind() == reflect.Func {
+			c.Print(item)
+		} else {
+			c.Print(bl("%v", item))
+		}
+	}
+	c.Print(" ")
+}
+
 func errorMsg(c *ishell.Context, message string, params ...interface{}) {
 	c.Println(red(fmt.Sprintf(message, params...)))
 }

--- a/readme.md
+++ b/readme.md
@@ -104,8 +104,13 @@ Delete alias `<alias-name`> from index `<index-name>`
     index close [--index <index-name>]
 Closes index. Closed index is not available for read or write
 
-    index open [-- index <index-name>]
+    index open [--index <index-name>]
 Opens previously closed index. 
+
+    index copy [--index <index-name>] --target <target-index-name>
+Copies mappings and documents from `<index-name>` to `<target-index-name>`. Target index should not exist. No index settings or
+aliases are copied. For ES version 2.4 and above this will use `_reindex` API. For older Elasticsearch versions all the documents will
+be copied using bulk APIs. There is no progress indication, so be patient. 
 
 ### Snapshot commands
 


### PR DESCRIPTION
Added `index copy` command,

implemented as `_reindex` for ES >= 2.3 and as bulk copy of all the documents for ES < 2.3
